### PR TITLE
fix: Pass JIRA secrets to reusable release documentation workflow

### DIFF
--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -18,3 +18,6 @@ jobs:
       backfill_days: ${{ fromJSON(inputs.backfill_days || '0') }}
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JIRA_URL: ${{ secrets.JIRA_URL }}
+      JIRA_USER: ${{ secrets.JIRA_USER }}
+      JIRA_API_KEY: ${{ secrets.JIRA_API_KEY }}


### PR DESCRIPTION
## Summary
- Fixes JIRA credential warnings in Release Documentation workflow
- Passes organization-level JIRA secrets to the reusable workflow

## Problem
The workflow was showing these warnings:
```
WARNING - JIRA credentials not provided - JIRA updates will be skipped
WARNING - JIRA client not enabled - skipping repo tags updates
```

This occurred because organization-level secrets were not being explicitly passed to the reusable workflow in `vyasa-analytics/release-auditing`.

## Solution
Explicitly pass JIRA secrets from the organization level:
- `JIRA_URL`
- `JIRA_USER`
- `JIRA_API_KEY`

## Dependencies
- Requires https://github.com/vyasa-analytics/release-auditing/commit/2fa176b which declares these secrets in the reusable workflow interface (already merged to main)

## Test Plan
- [ ] Merge this PR
- [ ] Trigger the Release Documentation workflow manually
- [ ] Verify no JIRA warning messages appear
- [ ] Verify JIRA repo tags are successfully updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)